### PR TITLE
Use 'document' type for Mux assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "sanity-plugin-mux-input",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "An input component that integrates Sanity Studio with MUX.com video encoding/hosting service.",
   "main": "build/index.js",
   "scripts": {
     "build": "babel src -d build --copy-files",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepublish": "npm run build"
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/schema/mux.videoAsset.js
+++ b/src/schema/mux.videoAsset.js
@@ -1,6 +1,6 @@
 export default {
   name: 'mux.videoAsset',
-  type: 'object',
+  type: 'document',
   title: 'Video asset',
   fields: [
     {


### PR DESCRIPTION
Consider using 'document' for mux video assets so the types show up in GraphQL. Side-effect is that these documents may show up in auto-generated studio menus.